### PR TITLE
feat: send pending messages after server comes online by maintaining a message queue

### DIFF
--- a/packages/client/src/Client.test.ts
+++ b/packages/client/src/Client.test.ts
@@ -140,6 +140,37 @@ describe('client', () => {
         })
       })
     })
+
+    describe('open', () => {
+      it('stays open when peer disconnects', async done => {
+        const { alice, bob } = setup()
+
+        await allConnected(alice, bob)
+
+        expect(alice.open).toBe(true)
+        expect(bob.open).toBe(true)
+
+        alice.disconnectPeer(bob.userName)
+        expect(alice.open).toBe(true)
+        expect(bob.open).toBe(true)
+        done()
+      })
+
+      it('closes when server disconnects', async done => {
+        const { alice, bob } = setup()
+
+        await allConnected(alice, bob)
+
+        expect(alice.open).toBe(true)
+        expect(bob.open).toBe(true)
+
+        alice.on('server.disconnect', () => {
+          expect(alice.open).toBe(false)
+          done()
+        })
+        server.close()
+      })
+    })
   })
 })
 

--- a/packages/client/src/Client.test.ts
+++ b/packages/client/src/Client.test.ts
@@ -37,6 +37,24 @@ describe('client', () => {
     }
 
     describe('Alice and Bob both join', () => {
+      it('using only .join ', async () => {
+        // Alice and Bob both join a documentId
+        testId += 1
+        const alice = new Client({ userName: `alice-${testId}`, url })
+        const bob = new Client({ userName: `bob-${testId}`, url })
+
+        const documentId = `test-documentId-${testId}`
+        alice.join(documentId)
+        bob.join(documentId)
+
+        await allConnected(alice, bob)
+
+        expect(alice.has(bob.userName, documentId)).toBe(true)
+        expect(bob.has(alice.userName, documentId)).toBe(true)
+      })
+    })
+
+    describe('Alice and Bob both join', () => {
       it('joins a documentId and connects to a peer', async () => {
         // Alice and Bob both join a documentId
         const { alice, bob, documentId } = setup()

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -1,6 +1,5 @@
 import debug, { Debugger } from 'debug'
 import { EventEmitter } from './EventEmitter'
-// import TypedEmitter from 'typed-emitter'
 import { isReady } from './isReady'
 import { newid } from './newid'
 import { ClientOptions, DocumentId, Message, PeerSocketMap, UserName } from './types'
@@ -12,14 +11,6 @@ export interface PeerEventPayload {
   documentId: DocumentId
   socket: WebSocket
 }
-
-// interface ClientEvents {
-//   'server.connect': () => void
-//   'server.disconnect': () => void
-//   'peer.connect': ({ userName, documentId, socket }: PeerEventPayload) => void
-//   'peer.disconnect': ({ userName, documentId, socket }: PeerEventPayload) => void
-//   error: (ev: Event) => void
-// }
 
 /**
  * This is a client for `relay` that keeps track of all peers that the server connects you to, and
@@ -67,7 +58,7 @@ export class Client extends EventEmitter {
 
   public log: Debugger
 
-  /** 
+  /**
    * If the connection to the server is currently open
    */
   public open: boolean
@@ -294,7 +285,3 @@ export class Client extends EventEmitter {
     }
   }
 }
-
-// It's normal for a document with a lot of participants to have a lot of connections, so increase
-// the limit to avoid spurious warnings about emitter leaks.
-// EventEmitter.defaultMaxListeners = 500

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -61,6 +61,11 @@ export class Client extends (EventEmitter as new () => TypedEmitter<ClientEvents
 
   public log: Debugger
 
+  /** 
+   * If the connection to the server is currently open
+   */
+  public open: boolean
+
   private serverConnection: WebSocket
   private retryDelay: number
 
@@ -188,6 +193,7 @@ export class Client extends (EventEmitter as new () => TypedEmitter<ClientEvents
       this.retryDelay = this.minRetryDelay
       documentIds.forEach(documentId => this.join(documentId))
       this.emit('server.connect')
+      this.open = true
 
       this.heartbeat = setInterval(() => socket.send(HEARTBEAT), 5000)
     }
@@ -232,6 +238,7 @@ export class Client extends (EventEmitter as new () => TypedEmitter<ClientEvents
     }
 
     socket.onclose = () => {
+      this.open = false
       this.emit('server.disconnect')
 
       // stop heartbeat

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -46,22 +46,17 @@ export class Client extends EventEmitter {
   /** All the document IDs we're interested in */
   public documentIds: Set<DocumentId> = new Set()
 
-  /** All the peers we're connected to.
-   * (A 'peer' in this case is actually just a bunch of sockets -
+  /** All the peers we're connected to. (A 'peer' in this case is actually just a bunch of sockets -
    * one per documentId that we have in common.) */
   public peers: Map<UserName, PeerSocketMap> = new Map()
 
-  /**
-   * When disconnected, the delay in milliseconds before the next retry
-   */
+  /** When disconnected, the delay in milliseconds before the next retry */
   public retryDelay: number
 
-  public log: Debugger
-
-  /**
-   * If the connection to the server is currently open
-   */
+  /** Is the connection to the server currently open? */
   public open: boolean
+
+  public log: Debugger
 
   private serverConnection: WebSocket
 

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -60,10 +60,14 @@ export class Client extends EventEmitter {
    * one per documentId that we have in common.) */
   public peers: Map<UserName, PeerSocketMap> = new Map()
 
+  /**
+   * When disconnected, the delay in milliseconds before the next retry
+   */
+  public retryDelay: number
+
   public log: Debugger
 
   private serverConnection: WebSocket
-  private retryDelay: number
 
   private minRetryDelay: number
   private maxRetryDelay: number


### PR DESCRIPTION
This is helpful to know, before we start sending messages across the wire, that we've established or lost the connection with the relay. In some early tests, I noticed that if a client calls the `send` function when the server is not ready yet, it give some really unclear feedback and we wanted to cover the case where the server is unreachable and prevent actions/give feedback in the UI. 

~This PR doesn't capture the full scope of this problem, and shouldn't just be a boolean set on server.connect or server.disconnect (any client can handle this on their own). But how can the client be a bit better about managing it's own connection to the server and queuing up messages for when the server reconnects? What happens when `socket.send(HEARTBEAT)` fails? Perhaps this should instead be a property that is computed based upon the status of the heartbeat.~

EDIT: new queue should solve the problem more fundamentally so clients don't need to maintain the client connection state.
