### PR TITLE
fix: Only join documentids once per id

### DIFF
--- a/packages/client/src/Client.test.ts
+++ b/packages/client/src/Client.test.ts
@@ -60,6 +60,29 @@ describe('client', () => {
         expect(alice.has(bob.userName, anotherDocumentId)).toBe(true)
         expect(bob.has(alice.userName, anotherDocumentId)).toBe(true)
       })
+
+      it('emits peer.connect only once per peer connection', async () => {
+        // Alice and Bob both join a documentId
+        testId += 1 
+        let connections = 0;
+        const alice = new Client({ userName: `alice-${testId}`, url })
+
+        alice.on('peer.connect', () => {
+          connections++
+          expect(connections).toBe(1)
+        })
+        const bob = new Client({ userName: `bob-${testId}`, url })
+        const documentId = `test-documentId-${testId}`
+
+        bob.join(documentId)
+        alice.join(documentId)
+        alice.join(documentId)
+
+        await allConnected(alice, bob)
+
+        expect(alice.has(bob.userName, documentId)).toBe(true)
+        expect(bob.has(alice.userName, documentId)).toBe(true)
+      })
     })
 
     describe('Alice leaves a document', () => {

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -130,6 +130,7 @@ export class Client extends EventEmitter {
       const connectToPeer = (documentId: DocumentId, userName: UserName) => {
         const peer = this.get(userName)
         if (peer.has(documentId)) return // don't add twice
+        peer.set(documentId, { socket: null })
 
         const url = `${this.url}/connection/${this.userName}/${userName}/${documentId}`
         const socket = new WebSocket(url)
@@ -139,8 +140,7 @@ export class Client extends EventEmitter {
           await isReady(socket)
 
           // add the socket to the map for this peer
-          peer.set(documentId, socket)
-
+          peer.set(documentId, { socket })
           this.emit('peer.connect', { userName, documentId, socket })
         }
 
@@ -275,7 +275,7 @@ export class Client extends EventEmitter {
   private closeSocket(userName: UserName, documentId: DocumentId) {
     const peer = this.get(userName)
     if (peer.has(documentId)) {
-      const socket = peer.get(documentId)
+      const { socket }= peer.get(documentId)
       if (socket && socket.readyState !== socket.CLOSED && socket.readyState !== socket.CLOSING)
         socket.close()
       peer.delete(documentId)

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -52,4 +52,8 @@ export interface ClientOptions {
   backoffFactor?: number
 }
 
-export type PeerSocketMap = Map<DocumentId, WebSocket>
+export type Peer = {
+  socket: WebSocket
+}
+
+export type PeerSocketMap = Map<DocumentId, Peer>


### PR DESCRIPTION
I noticed that if building a client library for downstream app development, it can be unclear how and when a client should join the documentId. From a developer UX point of view, it was assumed the client would handle this on it's own. If this library doesn't handle that, then the downstream dev needs to maintain a set of document ids and sockets and check if one already exists, but this is duplicating the internal structure of the client library that already exists so is redundant. 

This one-liner prevents a lot of unnecessary websocket messages that could in practice be created if an app is implemented naively (which I found to be too easy to do!)