### PR TITLE
Fixed parse() server crash when sending non-JSON

### DIFF
--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -113,7 +113,7 @@ export class Server extends EventEmitter {
   private openIntroductionConnection(socket: WebSocket, userName: UserName) {
     this.peers[userName] = socket
 
-    socket.on('message', this.handleIntroductionRequest(userName))
+    socket.on('message', () => {try {this.handleIntroductionRequest(userName)} catch(e) {return}})
     socket.on('close', this.closeIntroductionConnection(userName))
 
     this.emit('introductionConnection', userName)

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -228,6 +228,9 @@ const tryParse = <T>(s: string): T | Error => {
   try {
     return JSON.parse(s)
   } catch (err) {
+    if (err instanceof SyntaxError) {
+      return new SyntaxError('Message is not valid JSON')
+    }
     return err
   }
 }

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -125,7 +125,7 @@ export class Server extends EventEmitter {
 
     const message = tryParse<Message.ClientToServer>(data.toString())
     if (message instanceof Error) {
-      console.warn({ error: message, data })
+      this.emit('error', { error: message, data })
       return
     }
 


### PR DESCRIPTION
Sending badly formatted data will crash the server, as seen here: https://ibb.co/9WTBJG5

This PR performs a try() and catch() to make sure the error gets caught and dealt with.

Since it seems there is support for bad cases (default: break for unknown types), I converted the error message to an empty JSON.

The options to deal with your problem are here: https://stackoverflow.com/questions/43090614/how-use-const-in-try-catch-block

I chose to deal with it in a one-liner for ease, but the best option would be to put the entire function into a try(), catch() block, and you can avoid any "let" variables as well as any casting or not immediately breaking out on a bad request.

Anyways, hope this gets solved. My method works here, but I would suggest the larger method of just encompassing the block of code entirely within try() and catch() to avoid any variables and unneccesary head.