### PR TITLE
fix: Patch vulnerability where malicious clients could deterministically crash server

### DIFF
--- a/packages/server/src/Server.test.ts
+++ b/packages/server/src/Server.test.ts
@@ -189,10 +189,8 @@ describe('Server', () => {
         }
       })
     })
-  })
 
-  describe('Handle errors gracefully', () => {
-    it('Should not crash when peer disconnects mid-introduction', done => {
+    it('Should not crash when one peer disconnects mid-introduction', done => {
       const { documentId } = setup()
       let introductions = 0
       const peers = ['a', 'b', 'c', 'd', 'e']

--- a/packages/server/src/Server.test.ts
+++ b/packages/server/src/Server.test.ts
@@ -201,9 +201,7 @@ describe('Server', () => {
 
       const expectedIntroductions = 4
 
-      const sockets = userNames.map(
-        (userName: string) => new WebSocket(`${url}/introduction/${userName}`)
-      )
+      const sockets = userNames.map(userName => new WebSocket(`${url}/introduction/${userName}`))
 
       sockets.forEach((socket: WebSocket) => {
 

--- a/packages/server/src/Server.test.ts
+++ b/packages/server/src/Server.test.ts
@@ -220,10 +220,10 @@ describe('Server', () => {
       })
 
       const joinMessage = { type: 'Join', documentIds: [documentId] }
-      sockets.forEach(async (socket: WebSocket) => {
+      sockets.forEach(async (socket, i) => {
         socket.onopen = () => {
           socket.send(JSON.stringify(joinMessage))
-          if (introductions === 0) socket.close()
+          if (i === 0) socket.close()
         }
       })
     })

--- a/packages/server/src/Server.test.ts
+++ b/packages/server/src/Server.test.ts
@@ -163,7 +163,7 @@ describe('Server', () => {
       let introductions = 0
       const peers = ['a', 'b', 'c', 'd', 'e']
 
-      const expectedIntroductions = factorial(peers.length) / factorial(peers.length - 2) // Permutations of 2
+      const expectedIntroductions = permutationsOfTwo(peers.length)
 
       const userNames = peers.map(userName => `peer-${userName}-${testId}`)
 
@@ -197,16 +197,11 @@ describe('Server', () => {
 
       const userNames = peers.map(userName => `peer-${userName}-${testId}`)
 
-      const expectedIntroductions = 4
+      const expectedIntroductions = permutationsOfTwo(peers.length - 1) // one will misbehave
 
       const sockets = userNames.map(userName => new WebSocket(`${url}/introduction/${userName}`))
 
-      sockets.forEach((socket: WebSocket) => {
-
-        socket.onopen = () => {
-          socket.send('malicious client can crash you :)')
-        }
-
+      sockets.forEach(socket => {
         socket.onmessage = event => {
           const { data } = event
           const message = JSON.parse(data.toString())
@@ -228,4 +223,5 @@ describe('Server', () => {
   })
 })
 
+const permutationsOfTwo = (n: number) => factorial(n) / factorial(n - 2)
 const factorial = (n: number): number => (n === 1 ? 1 : n * factorial(n - 1))

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -161,7 +161,7 @@ export class Server extends EventEmitter {
     }
   }
 
-  private _send(peer: WebSocket, message: Message.ServerToClient) {
+  private send(peer: WebSocket, message: Message.ServerToClient) {
     if (peer && peer.readyState === WebSocket.OPEN) {
       try {
         peer.send(JSON.stringify(message))
@@ -180,7 +180,7 @@ export class Server extends EventEmitter {
       documentIds, // the documentId(s) both are interested in
     }
     let peer = this.peers[A]
-    this._send(peer, message)
+    this.send(peer, message)
   }
 
   private closeIntroductionConnection = (userName: UserName) => () => {
@@ -208,7 +208,7 @@ export class Server extends EventEmitter {
 
       this.log(`found peer, connecting ${AseeksB} (${messages.length} stored messages)`)
       // Send any stored messages
-      messages.forEach(message => this._send(socket, message))
+      messages.forEach(message => this.send(socket, message))
 
       // Pipe the two sockets together
       pipeSockets(socketA, socketB)


### PR DESCRIPTION
Every time the server calls `WebSocket.send` it needs to guard against that call throwing an error, because if it does, the server crashes. I was also able to do this deterministically with relatively simple client code, so it is also a vulnerability that a malicious client could leverage to force the server down.

fixes #6 